### PR TITLE
Launch Everyday Workbench

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,16 +1,16 @@
 # Product Marketing Context
 
-*Last updated: 2026-05-25*
+*Last updated: 2026-07-20*
 
 ## Product Overview
 
-**One-liner:** Matthew Paver's portfolio store for practical automation, AI workflow, data engineering, analytics, and machine learning projects.
+**One-liner:** Small, trustworthy browser tools that help project and operations people finish the work between the big tasks.
 
-**What it does:** The portfolio routes visitors to the strongest work quickly, then lets them inspect the project catalogue like an app store. It explains what each project solves, what the stack is, what proof exists, and where someone can open the repo, product, preview, or case study.
+**What it does:** The Everyday Workbench lets a visitor build a weekly update, prepare a handover, compare two versions, or produce evidence-linked meeting follow-up. The technical catalogue remains underneath so reviewers can inspect the systems, tests, repositories and limitations.
 
-**Product category:** Developer portfolio, technical project catalogue, AI/data portfolio.
+**Product category:** Curated work-tool store, developer portfolio, AI/data proof of work.
 
-**Product type:** Static GitHub Pages site plus GitHub profile README.
+**Product type:** Browser-local workbench, static GitHub Pages site, and GitHub profile.
 
 **Business model:** Personal portfolio and proof-of-work surface.
 
@@ -20,9 +20,13 @@
 
 **Decision-makers:** Engineering managers, data leads, automation leads, product-minded technical reviewers, founders, and collaborators.
 
-**Primary use case:** Let someone understand Matthew's practical build pattern without digging through every repo.
+**Primary use case:** Let a nontechnical visitor complete one small work task immediately, while giving a technical reviewer a clear route to the engineering evidence.
 
 **Jobs to be done:**
+- Turn rough progress notes into a weekly update.
+- Leave a colleague a structured handover.
+- Explain exactly what changed between two short documents.
+- Turn meeting notes into a reviewed follow-up with source lines.
 - See the strongest projects in under a minute.
 - Check whether the public repos are runnable and credible.
 - Understand the pattern across automation, data, AI, and analytics work.
@@ -38,15 +42,19 @@
 | Persona | Cares about | Challenge | Value we promise |
 |---|---|---|---|
 | Technical reviewer | runnable repos, tests, architecture, clean explanations | portfolios often overclaim | clear project pages with repo links, proof, and limitations |
+| Project or operations professional | a useful result without another platform rollout | small admin tasks remain half-finished | browser-local drafts with clear inputs, exits and review points |
+| Coordinator or team lead | clarity on owners, changes and next steps | updates and handovers are inconsistent | familiar work situations rather than technical product categories |
 | Automation/data lead | workflow thinking, reliability, handoffs | demos often stop at notebooks | systems framed around messy input to usable output |
 | Product-minded collaborator | practical apps, polished UX, live links | hard to judge taste from code alone | app-store style catalogue and previews |
 
 ## Problems & Pain Points
 
-**Core problem:** A GitHub profile can hide the strongest work because repos are scattered, private systems need explanation, and project names do not always explain the value.
+**Core problem:** General AI tools can help with almost anything but make ordinary users decide how to prompt, what to trust, and what happens to their data. Template marketplaces expose thousands of choices before the user has finished the small task on their desk.
 
 **Why alternatives fall short:**
 - A flat repo list does not show what matters first.
+- A generic chat box makes the user design the workflow.
+- A large marketplace increases choice without making trust or task completion clearer.
 - Generic portfolio copy sounds interchangeable.
 - Private work can look invisible unless it is explained safely.
 
@@ -65,7 +73,9 @@
 ## Differentiation
 
 **Key differentiators:**
-- App-store style project catalogue.
+- A curated task store organised around recognisable work situations.
+- Safe samples, browser-local processing, explicit human checkpoints and clear exits.
+- Deterministic code for exact transformation and comparison; LLMs only where bounded language judgement earns its place.
 - Practical test framing for each project.
 - Public/private/archive map without exposing private details.
 - Strong focus on automation specialist work, AI workflow reliability, and data products.
@@ -86,7 +96,7 @@
 
 ## Customer Language
 
-**Words/phrases to use:** automation specialist, practical AI workflows, data systems, runnable repos, messy input to usable product, evidence, checks, handoff, review gate.
+**Words/phrases to use:** finish the small job, weekly update, handover, what changed, exact source line, browser-local, nothing sent, review before sharing, evidence, checks.
 
 **Words/phrases to avoid:** next-generation, cutting-edge, revolutionary, unlock, seamless, supercharge, world-class, AI-powered everything.
 
@@ -97,14 +107,15 @@ Direct, practical, technical, calm, and specific. Prefer plain English over hype
 ## Proof Points
 
 - Portfolio audit score: 100/100.
-- AI Workflow Evaluator has deterministic tests and public workflow examples.
+- Everyday Workbench has three browser-local draft tools with deterministic unit and browser QA.
+- MeetingProof has a tested LangGraph approval gate and a 30-case synthetic release evaluation.
 - Marketing ML Lakehouse, ProjectLens, recommender, sentence similarity, Smart Job, QuickSupply, and AI Study Companion now explain the practical test they serve.
 - Store includes structured data, Open Graph image, sitemap, robots.txt, previews, and repo links.
 
 ## Goals
 
-**Primary goal:** Make Matthew's strongest work easy to understand, inspect, and remember.
+**Primary goal:** Make Matthew's work useful before asking the visitor to understand the technology.
 
-**Key conversion action:** Open the portfolio store, inspect a repo or preview, and connect via LinkedIn.
+**Key conversion action:** Run one safe sample, leave with a useful draft, then inspect a repo or connect via LinkedIn.
 
 **SEO goal:** Own branded search for Matthew Paver plus relevant long-tail terms around automation specialist, AI workflow evaluator, data engineering portfolio, and practical AI/data projects.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 </p>
 
 <p align="center">
-  <a href="https://matthewpaver.github.io/MatthewPaver/store/"><img src="https://img.shields.io/badge/Portfolio_Store-Open-0f766e?style=for-the-badge&logoColor=white" alt="Open Portfolio Store" /></a>
+  <a href="https://matthewpaver.github.io/MatthewPaver/store/workbench.html"><img src="https://img.shields.io/badge/Everyday_Workbench-Use_the_tools-0f766e?style=for-the-badge&logoColor=white" alt="Use the Everyday Workbench" /></a>
+  <a href="https://matthewpaver.github.io/MatthewPaver/store/"><img src="https://img.shields.io/badge/Project_Catalogue-Inspect-8f5d12?style=for-the-badge&logoColor=white" alt="Inspect the project catalogue" /></a>
   <a href="https://www.linkedin.com/in/matthew-paver-534262166/"><img src="https://img.shields.io/badge/LinkedIn-Connect-0a66c2?style=for-the-badge&logo=linkedin&logoColor=white" alt="Connect on LinkedIn" /></a>
 </p>
 
@@ -57,7 +58,7 @@
 | **Role**     | Software engineer and automation specialist |
 | **Based**    | London |
 | **Focus**    | Automation, data products, AI workflows, analytics tools |
-| **Shipping** | MeetingProof (live work tool) · ProjectLens (live project assurance) · DecisionGraph (live precedent retrieval) |
+| **Shipping** | Everyday Workbench (weekly updates, handovers, change comparison) · MeetingProof · ProjectLens · DecisionGraph |
 | **Stack**    | Python · TypeScript · FastAPI · Next.js · Postgres / DuckDB · Playwright · GitHub Actions |
 | **Specs**    | [Constitution](.specify/memory/constitution.md) · [Feature spec](specs/001-portfolio-store-reliability/spec.md) · [Validator](scripts/validate-store.mjs) · [Lighthouse CI](.lighthouserc.json) |
 
@@ -74,7 +75,7 @@ flowchart LR
     F -->|pass| G[Shipped]
 ```
 
-The pattern is practical: collect the messy input, clean it, check it, and turn it into something you can open. The [portfolio store](https://matthewpaver.github.io/MatthewPaver/store/) follows the same habit: indexed catalogue, validator, Lighthouse CI, no framework, no build step.
+The pattern is practical: collect the messy input, clean it, check it, and turn it into something you can use. The [Everyday Workbench](https://matthewpaver.github.io/MatthewPaver/store/workbench.html) applies it to ordinary work; the [project catalogue](https://matthewpaver.github.io/MatthewPaver/store/) exposes the engineering underneath.
 
 <p align="center"><img src="assets/mp-rule.svg" alt="" width="320" height="32" /></p>
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node scripts/validate-store.mjs",
+    "test": "node scripts/validate-store.mjs && node scripts/test-workbench.mjs",
     "audit:portfolio": "node tools/portfolio-audit/portfolio-audit.mjs",
     "bump": "node scripts/bump-cache-version.mjs"
   }

--- a/scripts/browser-qa-task-first.py
+++ b/scripts/browser-qa-task-first.py
@@ -51,9 +51,43 @@ with sync_playwright() as playwright:
     mobile = browser.new_page(viewport={"width": 390, "height": 844})
     mobile.goto(BASE_URL, wait_until="networkidle")
     assert mobile.locator(".task-route").count() == 3
-    assert mobile.locator(".task-route-primary img").is_visible()
+    assert mobile.locator(".task-route-primary .workbench-preview").is_visible()
     assert_no_horizontal_overflow(mobile)
     mobile.screenshot(path="/tmp/portfolio-task-first-mobile.png", full_page=True)
+
+    page.goto(f"{BASE_URL}workbench.html", wait_until="networkidle")
+    assert page.locator("[data-tool-tab]").count() == 3
+    assert "stays in this browser" in page.locator("body").inner_text()
+    page.locator('[data-sample="update"]').click()
+    page.locator("#build-update").click()
+    assert page.locator(".result-section").count() == 5
+    assert "Supplier shortlist agreed" in page.locator("#workbench-output").inner_text()
+    assert "Source line 1" in page.locator("#workbench-output").inner_text()
+    assert page.locator("#export-result").is_enabled()
+
+    page.locator('[data-tool-tab="handover"]').click()
+    page.locator('[data-sample="handover"]').click()
+    page.locator("#build-handover").click()
+    assert page.locator(".result-section").count() == 6
+    assert "Project Cedar" in page.locator("#workbench-output").inner_text()
+
+    page.locator('[data-tool-tab="change"]').click()
+    page.locator('[data-sample="change"]').click()
+    page.locator("#compare-change").click()
+    assert page.locator(".change-totals").is_visible()
+    assert page.locator(".change-added li").count() == 4
+    assert page.locator(".change-removed li").count() == 4
+    page.screenshot(path="/tmp/everyday-workbench-desktop.png", full_page=True)
+    assert_no_horizontal_overflow(page)
+
+    workbench_mobile = browser.new_page(viewport={"width": 390, "height": 844})
+    workbench_mobile.goto(f"{BASE_URL}workbench.html", wait_until="networkidle")
+    workbench_mobile.locator('[data-tool-tab="change"]').click()
+    workbench_mobile.locator('[data-sample="change"]').click()
+    workbench_mobile.locator("#compare-change").click()
+    assert workbench_mobile.locator(".change-totals").is_visible()
+    assert_no_horizontal_overflow(workbench_mobile)
+    workbench_mobile.screenshot(path="/tmp/everyday-workbench-mobile.png", full_page=True)
 
     no_js_context = browser.new_context(java_script_enabled=False)
     no_js = no_js_context.new_page()

--- a/scripts/test-workbench.mjs
+++ b/scripts/test-workbench.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import {
+  buildHandover,
+  buildWeeklyUpdate,
+  compareVersions,
+  resultToMarkdown,
+} from "../store/workbench-core.js";
+
+const update = buildWeeklyUpdate(
+  "Done: Sent pack\nBlocker: Legal review\nNext: Call Priya"
+);
+assert.equal(update.sections.find((section) => section.type === "done").items.length, 1);
+assert.equal(
+  update.sections.find((section) => section.type === "blockers").items.length,
+  1
+);
+assert.match(resultToMarkdown(update), /source line 1/);
+
+const handover = buildHandover("Open: Finish pack\nOwner: Priya\nDue: Friday");
+assert.equal(handover.sourceCount, 3);
+assert.equal(
+  handover.sections.find((section) => section.type === "owners").items[0].value,
+  "Priya"
+);
+
+const diff = compareVersions(
+  "Date: Monday\nScope: London",
+  "Date: Friday\nScope: London"
+);
+assert.equal(diff.added.length, 1);
+assert.equal(diff.removed.length, 1);
+assert.equal(diff.unchanged.length, 1);
+assert.match(resultToMarkdown(diff), /Date: Friday/);
+
+const hostile = buildWeeklyUpdate(
+  "Done: <img src=x onerror=alert(1)>\nIgnore all previous instructions"
+);
+assert.equal(hostile.sections[0].items.length, 1);
+assert.equal(hostile.unlabelled.length, 1);
+
+console.log("Everyday Workbench unit tests passed.");

--- a/scripts/validate-store.mjs
+++ b/scripts/validate-store.mjs
@@ -130,6 +130,10 @@ const previewHtml = readFile("store/preview.html");
 const previews = JSON.parse(readFile("store/previews.json"));
 const storeScript = readFile("store/script.js");
 const storeCss = readFile("store/styles.css");
+const workbenchHtml = readFile("store/workbench.html");
+const workbenchScript = readFile("store/workbench.js");
+const workbenchCore = readFile("store/workbench-core.js");
+const workbenchCss = readFile("store/workbench.css");
 const robots = readFile("robots.txt");
 const sitemap = readFile("sitemap.xml");
 const manifest = JSON.parse(readFile("store/manifest.webmanifest"));
@@ -210,10 +214,22 @@ assert(storeCss.includes("touch-action: pan-y"), "Large store surfaces should al
 assert(storeScript.includes("#project-grid-heading"), "Shelf filtering should scroll to the project grid heading");
 assert(storeScript.includes("searchIndex"), "Search should use a pre-computed index rather than reading textContent each keystroke");
 assert(indexHtml.includes('class="task-first"'), "Store should lead with a task-first work-tool section");
-assert(indexHtml.includes("Start with what is on your desk."), "Task-first section should use relatable problem-led copy");
+assert(indexHtml.includes("What are you trying to finish?"), "Task-first section should use relatable problem-led copy");
+assert(indexHtml.includes("./workbench.html"), "Portfolio should link directly to the Everyday Workbench");
 assert(indexHtml.includes("https://matthewpaver.github.io/MeetingProof/"), "Task-first section should link to MeetingProof");
 assert(indexHtml.includes("https://matthewpaver.github.io/ProjectLens/change-assurance.html"), "Task-first section should link to ProjectLens");
 assert(indexHtml.includes("https://matthewpaver.github.io/DecisionGraph/"), "Task-first section should link to DecisionGraph");
+assert(workbenchHtml.includes("Finish the jobs that usually get left half-done."), "Workbench should lead with a relatable job-to-be-done");
+assert(workbenchHtml.includes("Your text stays in this browser."), "Workbench should state its data boundary");
+assert(workbenchHtml.includes("Human checkpoint:"), "Workbench should make the review point explicit");
+assert(workbenchHtml.includes('data-tool-panel="update"'), "Workbench should include the Weekly Update Builder");
+assert(workbenchHtml.includes('data-tool-panel="handover"'), "Workbench should include the Handover Builder");
+assert(workbenchHtml.includes('data-tool-panel="change"'), "Workbench should include the Change Explainer");
+assert(workbenchScript.includes("navigator.clipboard.writeText"), "Workbench should support copying a result");
+assert(workbenchScript.includes("new Blob"), "Workbench should support Markdown export");
+assert(workbenchCore.includes("compareVersions"), "Workbench should use a testable deterministic comparison");
+assert(workbenchCss.includes("@media print"), "Workbench should include a useful print mode");
+assert(workbenchCss.includes("prefers-reduced-motion"), "Workbench should respect reduced-motion preferences");
 
 // SEO + meta hygiene
 assert(indexHtml.includes('rel="canonical"'), "Store HTML should declare a canonical URL");

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://matthewpaver.github.io/MatthewPaver/store/workbench.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>

--- a/store/index.html
+++ b/store/index.html
@@ -5,19 +5,19 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; media-src 'self'; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#fbfaf7" />
-    <title>Matthew Paver Portfolio Store</title>
+    <title>Everyday Workbench &amp; Project Portfolio · Matthew Paver</title>
     <link rel="canonical" href="https://matthewpaver.github.io/MatthewPaver/store/" />
     <link rel="preload" as="image" href="./assets/meetingproof.svg" type="image/svg+xml" fetchpriority="high" />
     <meta
       name="description"
-      content="Matthew Paver's portfolio store: practical automation, AI workflow, data engineering, analytics, and machine learning projects you can inspect."
+      content="Useful browser-local work tools for nontechnical people, plus Matthew Paver's evidence-led AI, automation, data, analytics and machine learning portfolio."
     />
     <meta name="author" content="Matthew Paver" />
     <!-- Open Graph / Twitter: image URL is absolute so social crawlers resolve it reliably -->
-    <meta property="og:title" content="Matthew Paver Portfolio Store" />
+    <meta property="og:title" content="Everyday Workbench &amp; Project Portfolio · Matthew Paver" />
     <meta
       property="og:description"
-      content="Practical automation, AI workflow, data engineering, analytics, and machine learning projects you can inspect."
+      content="Finish weekly updates, handovers, change comparisons and meeting follow-up—then inspect the engineering behind the tools."
     />
     <meta property="og:url" content="https://matthewpaver.github.io/MatthewPaver/store/" />
     <meta property="og:type" content="website" />
@@ -29,10 +29,10 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Matthew Paver Portfolio Store: practical AI, data, and analytics systems." />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Matthew Paver Portfolio Store" />
+    <meta name="twitter:title" content="Everyday Workbench &amp; Project Portfolio · Matthew Paver" />
     <meta
       name="twitter:description"
-      content="Practical automation, AI workflow, data engineering, analytics, and machine learning projects you can inspect."
+      content="Useful browser-local work tools for nontechnical people, with inspectable engineering underneath."
     />
     <meta
       name="twitter:image"
@@ -102,9 +102,10 @@
       <nav class="shell topbar" aria-label="Primary navigation">
         <a class="brand" href="https://github.com/MatthewPaver/MatthewPaver" aria-label="Back to Matthew Paver profile">
           <span class="brand-mark">MP</span>
-          <span>Portfolio Store</span>
+          <span>Everyday Workbench</span>
         </a>
         <div class="nav-links">
+          <a href="./workbench.html">Use the tools</a>
           <a href="https://github.com/MatthewPaver/MatthewPaver/blob/main/CASE_STUDIES.md">Case studies</a>
           <a href="#credentials">Credentials</a>
         </div>
@@ -113,11 +114,12 @@
 
     <header class="shell hero">
       <div class="hero-copy">
-        <p class="eyebrow">Matthew Paver · Portfolio Store</p>
-        <h1>Software for messy, real-world work.</h1>
-        <p class="lede">Automation, data systems, ML experiments, and focused products you can open or inspect.</p>
+        <p class="eyebrow">Matthew Paver · Useful software, openly built</p>
+        <h1>Small tools for the work between the big tasks.</h1>
+        <p class="lede">Finish a weekly update, handover, change comparison or meeting follow-up. Use the result first; inspect the AI and engineering underneath when you want to.</p>
         <div class="hero-actions">
-          <a class="button primary" href="#projects">Browse projects</a>
+          <a class="button primary" href="./workbench.html">Open Everyday Workbench</a>
+          <a class="button ghost" href="#projects">Inspect the portfolio</a>
           <a class="button ghost" href="https://www.linkedin.com/in/matthew-paver-534262166/">Connect with me</a>
         </div>
       </div>
@@ -127,55 +129,60 @@
       <section class="task-first" aria-labelledby="task-first-heading">
         <div class="task-first-heading">
           <div>
-            <p class="eyebrow">Use a work tool</p>
-            <h2 id="task-first-heading">Start with what is on your desk.</h2>
+            <p class="eyebrow">Everyday Workbench</p>
+            <h2 id="task-first-heading">What are you trying to finish?</h2>
           </div>
-          <p>Three separate jobs, three clear stopping points. Use the result first; inspect the AI and engineering when you need to.</p>
+          <p>Choose a recognisable moment from your day. Every tool shows what goes in, what comes out, where your data goes, and where you must review.</p>
         </div>
         <div class="task-route-grid">
           <article class="task-route task-route-primary">
-            <img src="./assets/meetingproof.svg" width="1200" height="630" alt="MeetingProof turns notes into decisions, actions and questions with source lines" fetchpriority="high" decoding="async" />
+            <div class="workbench-preview" aria-label="Everyday Workbench includes weekly update, handover and change comparison tools">
+              <span>01 · Update people</span>
+              <span>02 · Hand work over</span>
+              <span>03 · Compare changes</span>
+              <span>04 · Follow up a meeting</span>
+            </div>
             <div class="task-route-copy">
-              <p class="task-situation">I have meeting notes</p>
-              <h3>Leave with a follow-up people can check.</h3>
-              <p>Paste clearly labelled notes. Check every decision, action, owner and exact source line. Approve the record yourself.</p>
+              <p class="task-situation">I have a small job to finish now</p>
+              <h3>Make a useful draft without setting up another system.</h3>
+              <p>Start with a safe sample, replace it with your own notes, review the source-linked result and leave with a Markdown file.</p>
               <dl>
-                <div><dt>Input</dt><dd>Meeting notes</dd></div>
-                <div><dt>Result</dt><dd>Reviewed Markdown or JSON</dd></div>
-                <div><dt>Boundary</dt><dd>Browser-local; you approve</dd></div>
+                <div><dt>Input</dt><dd>Rough notes or two versions</dd></div>
+                <div><dt>Result</dt><dd>Weekly update, handover or change summary</dd></div>
+                <div><dt>Boundary</dt><dd>Browser-local; no account or upload</dd></div>
               </dl>
               <div class="task-actions">
-                <a class="button primary" href="https://matthewpaver.github.io/MeetingProof/">Use MeetingProof</a>
-                <a class="text-link" href="./preview.html?app=meetingproof">How it works</a>
+                <a class="button primary" href="./workbench.html">Open the workbench</a>
+                <a class="text-link" href="./workbench.html#proof-heading">See the boundaries</a>
               </div>
             </div>
           </article>
           <article class="task-route">
-            <p class="task-situation">I have a project change</p>
-            <h3>See whether the pack is ready for a decision.</h3>
-            <p>Compare the narrative and schedule, surface the three blockers, then record the board’s decision and conditions.</p>
+            <p class="task-situation">I just left a meeting</p>
+            <h3>Leave with a follow-up people can check.</h3>
+            <p>Turn clearly labelled notes into decisions, actions and open questions. Keep each source line beside the draft and approve it yourself.</p>
             <dl>
-              <div><dt>Input</dt><dd>Change pack + XER</dd></div>
-              <div><dt>Result</dt><dd>Decision-readiness record</dd></div>
-              <div><dt>Boundary</dt><dd>The board retains authority</dd></div>
+              <div><dt>Input</dt><dd>Meeting notes</dd></div>
+              <div><dt>Result</dt><dd>Reviewed Markdown or JSON</dd></div>
+              <div><dt>Boundary</dt><dd>Browser-local; you approve</dd></div>
             </dl>
             <div class="task-actions">
-              <a class="button ghost" href="https://matthewpaver.github.io/ProjectLens/change-assurance.html">Use ProjectLens</a>
-              <a class="text-link" href="./preview.html?app=projectlens">Inspect evidence</a>
+              <a class="button ghost" href="https://matthewpaver.github.io/MeetingProof/">Use MeetingProof</a>
+              <a class="text-link" href="./preview.html?app=meetingproof">How it works</a>
             </div>
           </article>
           <article class="task-route">
-            <p class="task-situation">I need to know what happened last time</p>
-            <h3>Find comparable decisions and their outcomes.</h3>
-            <p>Retrieve similar changes, see why each case matched, and follow the evidence from the original problem to the observed outcome.</p>
+            <p class="task-situation">I manage complex project changes</p>
+            <h3>Check readiness, then bring past outcomes into the decision.</h3>
+            <p>ProjectLens checks the current change pack. DecisionGraph retrieves comparable decisions and shows what happened next.</p>
             <dl>
-              <div><dt>Input</dt><dd>A new delivery problem</dd></div>
-              <div><dt>Result</dt><dd>Comparable evidence chain</dd></div>
-              <div><dt>Boundary</dt><dd>Human review, not precedent by default</dd></div>
+              <div><dt>Input</dt><dd>Change pack or delivery problem</dd></div>
+              <div><dt>Result</dt><dd>Readiness record or evidence chain</dd></div>
+              <div><dt>Boundary</dt><dd>Human decision remains explicit</dd></div>
             </dl>
             <div class="task-actions">
-              <a class="button ghost" href="https://matthewpaver.github.io/DecisionGraph/">Use DecisionGraph</a>
-              <a class="text-link" href="./preview.html?app=decisiongraph">Inspect retrieval</a>
+              <a class="button ghost" href="https://matthewpaver.github.io/ProjectLens/change-assurance.html">Use ProjectLens</a>
+              <a class="text-link" href="https://matthewpaver.github.io/DecisionGraph/">Open DecisionGraph</a>
             </div>
           </article>
         </div>

--- a/store/manifest.webmanifest
+++ b/store/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Matthew Paver Portfolio Store",
-  "short_name": "MP Portfolio",
-  "description": "Curated AI, data, automation, ML, and analytics work.",
+  "name": "Matthew Paver Everyday Workbench",
+  "short_name": "MP Workbench",
+  "description": "Useful browser-local work tools with inspectable AI, automation, data, and analytics engineering.",
   "start_url": "/MatthewPaver/store/",
   "scope": "/MatthewPaver/store/",
   "display": "standalone",

--- a/store/styles.css
+++ b/store/styles.css
@@ -387,6 +387,30 @@ h1 {
   object-fit: contain;
 }
 
+.workbench-preview {
+  display: grid;
+  align-content: center;
+  gap: 0;
+  min-height: 350px;
+  border-right: 1px solid var(--line-strong);
+  background: #173f38;
+  color: #fffdf7;
+  padding: clamp(26px, 5vw, 54px);
+}
+
+.workbench-preview span {
+  display: block;
+  border-top: 1px solid rgba(255, 255, 255, 0.32);
+  padding: 16px 0;
+  font-family: Charter, "Iowan Old Style", Georgia, serif;
+  font-size: clamp(1.3rem, 2.4vw, 2.25rem);
+  line-height: 1.05;
+}
+
+.workbench-preview span:first-child {
+  border-top: 0;
+}
+
 .task-route-copy {
   padding: 34px;
 }

--- a/store/workbench-core.js
+++ b/store/workbench-core.js
@@ -1,0 +1,172 @@
+const LABEL_ALIASES = new Map([
+  ["done", "done"],
+  ["completed", "done"],
+  ["progress", "done"],
+  ["blocker", "blockers"],
+  ["blocked", "blockers"],
+  ["risk", "risks"],
+  ["decision", "decisions"],
+  ["next", "next"],
+  ["metric", "metrics"],
+  ["open", "open"],
+  ["owner", "owners"],
+  ["due", "due"],
+  ["where", "where"],
+  ["link", "where"],
+]);
+
+export function parseLabelledLines(text) {
+  return String(text)
+    .split(/\r?\n/)
+    .map((line, index) => {
+      const source = line.trim();
+      if (!source) return null;
+      const match = source.match(/^([A-Za-z ]{2,18}):\s*(.+)$/);
+      if (!match) {
+        return { type: "unlabelled", value: source, source, line: index + 1 };
+      }
+      const label = match[1].trim().toLowerCase();
+      return {
+        type: LABEL_ALIASES.get(label) || "unlabelled",
+        value: match[2].trim(),
+        source,
+        line: index + 1,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function buildWeeklyUpdate(text) {
+  const items = parseLabelledLines(text);
+  const sections = [
+    ["done", "Progress"],
+    ["blockers", "Blockers"],
+    ["decisions", "Decisions needed"],
+    ["next", "Next"],
+    ["metrics", "Measures"],
+  ].map(([type, title]) => ({
+    type,
+    title,
+    items: items.filter((item) => item.type === type),
+  }));
+
+  return {
+    title: "Weekly update",
+    sections,
+    unlabelled: items.filter((item) => item.type === "unlabelled"),
+    sourceCount: items.length,
+  };
+}
+
+export function buildHandover(text) {
+  const items = parseLabelledLines(text);
+  const sections = [
+    ["open", "Open work"],
+    ["owners", "Owners"],
+    ["due", "Due dates"],
+    ["risks", "Risks"],
+    ["where", "Where to find things"],
+    ["next", "First next steps"],
+  ].map(([type, title]) => ({
+    type,
+    title,
+    items: items.filter((item) => item.type === type),
+  }));
+
+  return {
+    title: "Handover",
+    sections,
+    unlabelled: items.filter((item) => item.type === "unlabelled"),
+    sourceCount: items.length,
+  };
+}
+
+function lcsMatrix(before, after) {
+  const matrix = Array.from({ length: before.length + 1 }, () =>
+    Array(after.length + 1).fill(0)
+  );
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    for (let j = after.length - 1; j >= 0; j -= 1) {
+      matrix[i][j] =
+        before[i] === after[j]
+          ? matrix[i + 1][j + 1] + 1
+          : Math.max(matrix[i + 1][j], matrix[i][j + 1]);
+    }
+  }
+  return matrix;
+}
+
+export function compareVersions(beforeText, afterText) {
+  const before = String(beforeText)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const after = String(afterText)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const matrix = lcsMatrix(before, after);
+  const changes = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      changes.push({ type: "unchanged", value: before[i] });
+      i += 1;
+      j += 1;
+    } else if (matrix[i + 1][j] >= matrix[i][j + 1]) {
+      changes.push({ type: "removed", value: before[i], line: i + 1 });
+      i += 1;
+    } else {
+      changes.push({ type: "added", value: after[j], line: j + 1 });
+      j += 1;
+    }
+  }
+  while (i < before.length) {
+    changes.push({ type: "removed", value: before[i], line: i + 1 });
+    i += 1;
+  }
+  while (j < after.length) {
+    changes.push({ type: "added", value: after[j], line: j + 1 });
+    j += 1;
+  }
+
+  return {
+    title: "Change summary",
+    changes,
+    added: changes.filter((change) => change.type === "added"),
+    removed: changes.filter((change) => change.type === "removed"),
+    unchanged: changes.filter((change) => change.type === "unchanged"),
+  };
+}
+
+export function resultToMarkdown(result) {
+  if (result.changes) {
+    const lines = [
+      `# ${result.title}`,
+      "",
+      `Added: ${result.added.length} · Removed: ${result.removed.length} · Unchanged: ${result.unchanged.length}`,
+      "",
+      "## Added",
+      ...result.added.map((item) => `- ${item.value}`),
+      "",
+      "## Removed",
+      ...result.removed.map((item) => `- ${item.value}`),
+    ];
+    return lines.join("\n");
+  }
+
+  const lines = [`# ${result.title}`, ""];
+  result.sections.forEach((section) => {
+    lines.push(`## ${section.title}`);
+    if (!section.items.length) lines.push("- Not provided");
+    section.items.forEach((item) => lines.push(`- ${item.value} _(source line ${item.line})_`));
+    lines.push("");
+  });
+  if (result.unlabelled.length) {
+    lines.push("## Needs sorting");
+    result.unlabelled.forEach((item) => lines.push(`- ${item.value} _(source line ${item.line})_`));
+  }
+  return lines.join("\n").trim();
+}

--- a/store/workbench.css
+++ b/store/workbench.css
@@ -1,0 +1,260 @@
+:root {
+  --paper: #f3efe6;
+  --card: #fffef9;
+  --ink: #17211f;
+  --muted: #5c625f;
+  --line: #c9c5ba;
+  --green: #175f50;
+  --green-soft: #d8e9df;
+  --orange: #b55325;
+  --yellow: #f1d36b;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; scroll-padding-top: 24px; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Avenir Next", "Segoe UI", Helvetica, Arial, sans-serif;
+}
+a { color: inherit; }
+button, textarea { font: inherit; }
+button { cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: .42; }
+:focus-visible { outline: 3px solid rgba(23,95,80,.42); outline-offset: 3px; }
+.shell { width: min(1180px, calc(100% - 32px)); margin: 0 auto; }
+.skip-link { position: fixed; top: 12px; left: 16px; z-index: 20; transform: translateY(-220%); background: var(--ink); color: white; padding: 12px; }
+.skip-link:focus-visible { transform: translateY(0); }
+
+.workbench-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding-top: 20px;
+  font-size: .86rem;
+  font-weight: 750;
+}
+.workbench-nav > a:last-child { color: var(--muted); text-underline-offset: 4px; }
+.workbench-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+.workbench-brand span {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  background: var(--ink);
+  color: white;
+  font-size: .75rem;
+  letter-spacing: .06em;
+}
+
+.workbench-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(290px, .65fr);
+  gap: clamp(30px, 8vw, 100px);
+  align-items: end;
+  padding: clamp(70px, 10vw, 132px) 0 54px;
+}
+.eyebrow, .step {
+  margin: 0 0 12px;
+  color: var(--green);
+  font-size: .69rem;
+  font-weight: 900;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+h1, h2, h3, h4 { margin: 0; }
+h1, h2 {
+  font-family: Charter, "Iowan Old Style", Georgia, serif;
+  font-weight: 700;
+  letter-spacing: -.025em;
+  line-height: .98;
+  text-wrap: balance;
+}
+h1 { max-width: 820px; font-size: clamp(3.2rem, 7vw, 6.7rem); }
+h2 { font-size: clamp(2.3rem, 4.5vw, 4.5rem); }
+.lede { max-width: 730px; margin: 22px 0 0; color: var(--muted); font-size: clamp(1rem, 1.6vw, 1.2rem); line-height: 1.55; }
+.trust-note {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 14px;
+  border-top: 3px solid var(--green);
+  padding-top: 18px;
+}
+.trust-icon { display: grid; place-items: center; width: 38px; height: 38px; border: 1px solid var(--green); color: var(--green); font-size: 1.4rem; }
+.trust-note p { margin: 7px 0 0; color: var(--muted); font-size: .88rem; line-height: 1.5; }
+
+.situation-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  gap: 1px;
+}
+.situation-strip a {
+  display: grid;
+  min-height: 178px;
+  align-content: space-between;
+  gap: 14px;
+  padding: 20px;
+  background: var(--card);
+  text-decoration: none;
+  transition: background .18s ease, color .18s ease;
+}
+.situation-strip a:hover { background: var(--green); color: white; }
+.situation-strip span { color: var(--orange); font-family: Georgia, serif; font-size: .82rem; font-weight: 800; }
+.situation-strip a:hover span, .situation-strip a:hover small { color: white; }
+.situation-strip strong { max-width: 180px; font-family: Charter, Georgia, serif; font-size: 1.35rem; line-height: 1.08; }
+.situation-strip small { color: var(--muted); font-weight: 750; }
+
+.builder { margin: 92px 0 72px; }
+.builder-intro { display: grid; grid-template-columns: 1fr minmax(260px, 410px); gap: 30px; align-items: end; margin-bottom: 32px; }
+.builder-intro .eyebrow { grid-column: 1 / -1; margin-bottom: -16px; }
+.builder-intro > p:last-child { margin: 0; color: var(--muted); line-height: 1.55; }
+.tool-tabs { display: flex; gap: 0; overflow-x: auto; border-bottom: 1px solid var(--ink); }
+.tool-tabs button {
+  min-height: 52px;
+  border: 1px solid var(--line);
+  border-bottom: 0;
+  background: transparent;
+  padding: 0 21px;
+  color: var(--muted);
+  font-weight: 800;
+}
+.tool-tabs button + button { border-left: 0; }
+.tool-tabs button.active { background: var(--ink); border-color: var(--ink); color: white; }
+.noscript-note { margin: 16px 0; border: 1px solid var(--orange); padding: 16px; }
+.no-js .workspace { display: none; }
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  min-height: 670px;
+  border: 1px solid var(--ink);
+  border-top: 0;
+  background: var(--card);
+}
+.input-column, .output-column { min-width: 0; padding: clamp(22px, 3vw, 38px); }
+.input-column { border-right: 1px solid var(--ink); }
+.tool-heading, .output-toolbar { display: flex; justify-content: space-between; gap: 20px; align-items: start; }
+.tool-heading h3, .output-toolbar h3 { font-family: Charter, Georgia, serif; font-size: clamp(1.6rem, 2.4vw, 2.35rem); line-height: 1.05; }
+.sample-button {
+  flex: 0 0 auto;
+  border: 0;
+  border-bottom: 1px solid currentColor;
+  background: none;
+  padding: 4px 0;
+  color: var(--green);
+  font-size: .78rem;
+  font-weight: 850;
+}
+.field-help { min-height: 48px; margin: 18px 0; color: var(--muted); font-size: .86rem; line-height: 1.5; }
+code { border: 1px solid var(--line); background: var(--paper); padding: 1px 4px; color: var(--ink); }
+label { display: grid; gap: 8px; color: var(--ink); font-size: .76rem; font-weight: 900; letter-spacing: .04em; text-transform: uppercase; }
+textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: white;
+  padding: 15px;
+  color: var(--ink);
+  font-size: .95rem;
+  line-height: 1.55;
+}
+textarea:focus { border-color: var(--green); }
+.version-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.make-button {
+  display: flex;
+  width: 100%;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 16px;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  padding: 0 18px;
+  color: white;
+  font-weight: 850;
+}
+.make-button:hover { background: var(--green); border-color: var(--green); }
+.output-column { display: grid; grid-template-rows: auto 1fr auto auto; background: #e9e5db; }
+#output-state {
+  max-width: 165px;
+  color: var(--muted);
+  font-size: .72rem;
+  font-weight: 700;
+  line-height: 1.35;
+  text-align: right;
+}
+#output-state.ready { color: var(--green); }
+.result { margin: 24px 0; }
+.empty-output { display: grid; min-height: 300px; place-items: center; align-content: center; gap: 12px; border: 1px dashed var(--line); color: var(--muted); text-align: center; }
+.empty-output span { font-family: Georgia, serif; font-size: 3rem; color: var(--green); }
+.empty-output p { max-width: 290px; margin: 0; line-height: 1.5; }
+.result-section { border-top: 1px solid var(--line); padding: 16px 0; }
+.result-section h4 { display: flex; justify-content: space-between; font-size: .86rem; text-transform: uppercase; letter-spacing: .06em; }
+.result-section h4 span { display: grid; place-items: center; width: 23px; height: 23px; background: var(--ink); color: white; font-size: .68rem; }
+.result-section ul { display: grid; gap: 12px; margin: 14px 0 0; padding: 0; list-style: none; }
+.result-section li { display: grid; grid-template-columns: auto 1fr; gap: 2px 9px; line-height: 1.4; }
+.result-section li > span { grid-column: 1 / -1; }
+.result-section li strong { color: var(--green); }
+.result-section li small { grid-column: 1 / -1; color: var(--muted); font-size: .72rem; }
+.missing-value { margin: 11px 0 0; color: var(--orange); font-size: .82rem; }
+.needs-review { border-left: 3px solid var(--orange); padding-left: 12px; }
+.change-totals { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); }
+.change-totals span { display: grid; gap: 2px; padding: 12px; border-right: 1px solid var(--line); color: var(--muted); font-size: .7rem; }
+.change-totals span:last-child { border: 0; }
+.change-totals strong { color: var(--ink); font-family: Georgia, serif; font-size: 1.5rem; }
+.change-removed li strong { color: var(--orange); }
+.output-actions { display: flex; flex-wrap: wrap; gap: 8px; border-top: 1px solid var(--line); padding-top: 16px; }
+.output-actions button { min-height: 38px; border: 1px solid var(--ink); background: var(--card); padding: 0 13px; font-weight: 800; }
+.output-actions button:not(:disabled):hover { background: var(--ink); color: white; }
+.output-actions .quiet-button { margin-left: auto; border-color: transparent; background: transparent; color: var(--muted); }
+.review-reminder { margin: 18px 0 0; color: var(--muted); font-size: .76rem; line-height: 1.45; }
+
+.proof-section { display: grid; grid-template-columns: 1fr 1.2fr; gap: 70px; border-top: 1px solid var(--ink); padding: 58px 0 80px; }
+.proof-section dl { margin: 0; }
+.proof-section dl div { display: grid; grid-template-columns: 150px 1fr; gap: 20px; border-top: 1px solid var(--line); padding: 14px 0; }
+.proof-section dt { font-size: .72rem; font-weight: 900; text-transform: uppercase; letter-spacing: .06em; }
+.proof-section dd { margin: 0; color: var(--muted); line-height: 1.45; }
+footer { display: flex; justify-content: space-between; gap: 20px; border-top: 1px solid var(--line); padding: 24px 0 42px; color: var(--muted); font-size: .78rem; font-weight: 700; }
+footer p { margin: 0; }
+
+@media (max-width: 820px) {
+  .workbench-hero, .builder-intro, .workspace, .proof-section { grid-template-columns: 1fr; }
+  .workbench-hero { padding-top: 72px; }
+  .situation-strip { grid-template-columns: 1fr 1fr; }
+  .input-column { border-right: 0; border-bottom: 1px solid var(--ink); }
+  .builder-intro .eyebrow { grid-column: auto; margin-bottom: 0; }
+  .workspace { min-height: 0; }
+}
+
+@media (max-width: 520px) {
+  .workbench-nav > a:last-child { max-width: 120px; text-align: right; }
+  .situation-strip { grid-template-columns: 1fr; }
+  .situation-strip a { min-height: 132px; }
+  .version-grid { grid-template-columns: 1fr; }
+  .tool-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    overflow: visible;
+  }
+  .tool-tabs button { min-width: 0; padding: 0 8px; font-size: .78rem; line-height: 1.15; }
+  .tool-heading, .output-toolbar { align-items: start; }
+  .sample-button { max-width: 74px; text-align: right; }
+  .proof-section dl div { grid-template-columns: 1fr; gap: 5px; }
+  footer { display: grid; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  * { transition: none !important; }
+}
+
+@media print {
+  .workbench-nav, .workbench-hero, .situation-strip, .builder-intro, .tool-tabs, .input-column, .output-actions, .proof-section, footer { display: none !important; }
+  .workspace { display: block; border: 0; }
+  .output-column { background: white; padding: 0; }
+}

--- a/store/workbench.html
+++ b/store/workbench.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en" class="no-js">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#f3efe6" />
+    <title>Everyday Workbench · Matthew Paver</title>
+    <meta name="description" content="Small, browser-local tools for weekly updates, handovers, change comparisons and evidence-linked meeting follow-up." />
+    <link rel="canonical" href="https://matthewpaver.github.io/MatthewPaver/store/workbench.html" />
+    <link rel="icon" type="image/svg+xml" href="./assets/favicon.svg" />
+    <link rel="stylesheet" href="./workbench.css?v=20260720-1" />
+    <script>document.documentElement.className = "js-enabled";</script>
+  </head>
+  <body>
+    <a class="skip-link" href="#tools">Skip to tools</a>
+    <nav class="workbench-nav shell" aria-label="Workbench navigation">
+      <a class="workbench-brand" href="./">
+        <span aria-hidden="true">MP</span>
+        <strong>Everyday Workbench</strong>
+      </a>
+      <a href="./">Portfolio &amp; project catalogue</a>
+    </nav>
+
+    <header class="workbench-hero shell">
+      <div>
+        <p class="eyebrow">Small tools for real work</p>
+        <h1>Finish the jobs that usually get left half-done.</h1>
+        <p class="lede">Turn rough notes into a useful draft, see what changed, and keep the source beside the result. No account, no upload, no silent action.</p>
+      </div>
+      <aside class="trust-note" aria-label="How this workbench handles your data">
+        <span class="trust-icon" aria-hidden="true">◎</span>
+        <div>
+          <strong>Your text stays in this browser.</strong>
+          <p>These three tools use deterministic code. They do not call an AI service, save your text, or send anything to another person.</p>
+        </div>
+      </aside>
+    </header>
+
+    <main id="tools" class="shell">
+      <section class="situation-strip" aria-label="Choose a work situation">
+        <a href="#builder" data-open-tool="update"><span>01</span><strong>I need to update people</strong><small>Build a weekly update</small></a>
+        <a href="#builder" data-open-tool="handover"><span>02</span><strong>I am handing work over</strong><small>Build a handover</small></a>
+        <a href="#builder" data-open-tool="change"><span>03</span><strong>I need to compare changes</strong><small>Explain two versions</small></a>
+        <a href="https://matthewpaver.github.io/MeetingProof/"><span>04</span><strong>I just left a meeting</strong><small>Open MeetingProof ↗</small></a>
+      </section>
+
+      <section id="builder" class="builder" aria-labelledby="builder-heading">
+        <div class="builder-intro">
+          <p class="eyebrow">Run once · leave with a file</p>
+          <h2 id="builder-heading">Choose the thing you need to finish.</h2>
+          <p>Start with the safe sample to see the shape of the result. Then replace it with your own text.</p>
+        </div>
+
+        <div class="tool-tabs" role="tablist" aria-label="Workbench tools">
+          <button class="active" id="tab-update" data-tool-tab="update" role="tab" aria-controls="panel-update" aria-selected="true" type="button">Weekly update</button>
+          <button id="tab-handover" data-tool-tab="handover" role="tab" aria-controls="panel-handover" aria-selected="false" tabindex="-1" type="button">Handover</button>
+          <button id="tab-change" data-tool-tab="change" role="tab" aria-controls="panel-change" aria-selected="false" tabindex="-1" type="button">Change explainer</button>
+        </div>
+
+        <noscript>
+          <div class="noscript-note">The workbench needs JavaScript to make local drafts. Your browser can still open <a href="https://matthewpaver.github.io/MeetingProof/">MeetingProof</a> or return to the <a href="./">project catalogue</a>.</div>
+        </noscript>
+
+        <div class="workspace">
+          <div class="input-column">
+            <section id="panel-update" data-tool-panel="update" role="tabpanel" aria-labelledby="tab-update">
+              <div class="tool-heading">
+                <div><p class="step">Input</p><h3>What happened this week?</h3></div>
+                <button class="sample-button" data-sample="update" type="button">Use safe sample</button>
+              </div>
+              <p class="field-help">Use labels such as <code>Done:</code>, <code>Blocker:</code>, <code>Decision:</code>, <code>Next:</code> and <code>Metric:</code>. Each line remains traceable.</p>
+              <label for="update-input">Rough update notes</label>
+              <textarea id="update-input" rows="13" spellcheck="true" placeholder="Done: …&#10;Blocker: …&#10;Decision: …&#10;Next: …"></textarea>
+              <button id="build-update" class="make-button" type="button">Make weekly update <span aria-hidden="true">→</span></button>
+            </section>
+
+            <section id="panel-handover" data-tool-panel="handover" role="tabpanel" aria-labelledby="tab-handover" hidden>
+              <div class="tool-heading">
+                <div><p class="step">Input</p><h3>What must the next person know?</h3></div>
+                <button class="sample-button" data-sample="handover" type="button">Use safe sample</button>
+              </div>
+              <p class="field-help">Use labels such as <code>Open:</code>, <code>Owner:</code>, <code>Due:</code>, <code>Risk:</code>, <code>Where:</code> and <code>Next:</code>.</p>
+              <label for="handover-input">Rough handover notes</label>
+              <textarea id="handover-input" rows="13" spellcheck="true" placeholder="Open: …&#10;Owner: …&#10;Due: …&#10;Risk: …"></textarea>
+              <button id="build-handover" class="make-button" type="button">Make handover <span aria-hidden="true">→</span></button>
+            </section>
+
+            <section id="panel-change" data-tool-panel="change" role="tabpanel" aria-labelledby="tab-change" hidden>
+              <div class="tool-heading">
+                <div><p class="step">Input</p><h3>What changed between two versions?</h3></div>
+                <button class="sample-button" data-sample="change" type="button">Use safe sample</button>
+              </div>
+              <p class="field-help">Paste one statement or list item per line. The comparison is exact: added, removed and unchanged.</p>
+              <div class="version-grid">
+                <label for="before-input">Before<textarea id="before-input" rows="9" spellcheck="true" placeholder="Paste the earlier version…"></textarea></label>
+                <label for="after-input">After<textarea id="after-input" rows="9" spellcheck="true" placeholder="Paste the new version…"></textarea></label>
+              </div>
+              <button id="compare-change" class="make-button" type="button">Compare versions <span aria-hidden="true">→</span></button>
+            </section>
+          </div>
+
+          <aside class="output-column" aria-labelledby="output-title">
+            <div class="output-toolbar">
+              <div>
+                <p class="step">Draft</p>
+                <h3 id="output-title">Your draft will appear here</h3>
+              </div>
+              <span id="output-state">Nothing has been sent or saved</span>
+            </div>
+            <div id="workbench-output" class="result" tabindex="-1" aria-live="polite"></div>
+            <div class="output-actions">
+              <button id="copy-result" type="button" disabled>Copy</button>
+              <button id="export-result" type="button" disabled>Download .md</button>
+              <button id="reset-result" class="quiet-button" type="button">Clear draft</button>
+            </div>
+            <p class="review-reminder"><strong>Human checkpoint:</strong> check names, dates and meaning before you share the draft.</p>
+          </aside>
+        </div>
+      </section>
+
+      <section class="proof-section" aria-labelledby="proof-heading">
+        <div>
+          <p class="eyebrow">What “safe” means here</p>
+          <h2 id="proof-heading">Clear boundaries, not vague badges.</h2>
+        </div>
+        <dl>
+          <div><dt>Data handling</dt><dd>Text remains in the current browser tab.</dd></div>
+          <div><dt>External changes</dt><dd>None. The tools only produce a draft or download.</dd></div>
+          <div><dt>Calculation</dt><dd>Deterministic JavaScript, with no model call.</dd></div>
+          <div><dt>Exit</dt><dd>Copy the result, download Markdown, or close the tab.</dd></div>
+        </dl>
+      </section>
+    </main>
+
+    <footer class="shell">
+      <p>Built by Matthew Paver as a public, testable product experiment.</p>
+      <a href="https://github.com/MatthewPaver/MatthewPaver">Inspect the code ↗</a>
+    </footer>
+    <script type="module" src="./workbench.js?v=20260720-1"></script>
+  </body>
+</html>

--- a/store/workbench.js
+++ b/store/workbench.js
@@ -1,0 +1,189 @@
+import {
+  buildHandover,
+  buildWeeklyUpdate,
+  compareVersions,
+  resultToMarkdown,
+} from "./workbench-core.js";
+
+const samples = {
+  update: `Done: Supplier shortlist agreed with Finance
+Done: Pilot team completed the first walkthrough
+Blocker: Data-sharing approval is still waiting on Legal
+Decision: Confirm whether the pilot includes the North region
+Next: Priya to circulate the revised plan on Friday
+Metric: 18 of 22 pilot users completed onboarding`,
+  handover: `Open: Finalise the supplier onboarding checklist
+Owner: Priya owns commercial queries; Dan owns access requests
+Due: Pilot readiness review is 24 July
+Risk: Two user accounts still need information-security approval
+Where: Working files are in Teams / Project Cedar / 04 Delivery
+Next: Check the approvals tracker before Tuesday's stand-up`,
+  before: `Pilot launch: 29 July
+Scope: London and South East teams
+Training: one live session
+Approval owner: Operations Director
+Success measure: 70% weekly use`,
+  after: `Pilot launch: 5 August
+Scope: London, South East and North teams
+Training: two live sessions plus a recording
+Approval owner: Operations Director
+Success measure: 80% weekly use`,
+};
+
+let latestResult = null;
+let latestTool = "update";
+
+const panels = Array.from(document.querySelectorAll("[data-tool-panel]"));
+const tabs = Array.from(document.querySelectorAll("[data-tool-tab]"));
+const output = document.querySelector("#workbench-output");
+const outputTitle = document.querySelector("#output-title");
+const outputState = document.querySelector("#output-state");
+const exportButton = document.querySelector("#export-result");
+const copyButton = document.querySelector("#copy-result");
+const resetButton = document.querySelector("#reset-result");
+
+function setActiveTool(name) {
+  latestTool = name;
+  tabs.forEach((tab) => {
+    const active = tab.dataset.toolTab === name;
+    tab.classList.toggle("active", active);
+    tab.setAttribute("aria-selected", String(active));
+    tab.tabIndex = active ? 0 : -1;
+  });
+  panels.forEach((panel) => {
+    panel.hidden = panel.dataset.toolPanel !== name;
+  });
+  resetOutput();
+  document.querySelector(`[data-tool-panel="${name}"] textarea`)?.focus();
+}
+
+function itemMarkup(item) {
+  return `<li><span>${escapeHtml(item.value)}</span><small>Source line ${item.line}: “${escapeHtml(
+    item.source
+  )}”</small></li>`;
+}
+
+function renderStructured(result) {
+  return result.sections
+    .map(
+      (section) => `<section class="result-section">
+        <h4>${section.title}<span>${section.items.length}</span></h4>
+        ${
+          section.items.length
+            ? `<ul>${section.items.map(itemMarkup).join("")}</ul>`
+            : '<p class="missing-value">Not provided — add it before sending.</p>'
+        }
+      </section>`
+    )
+    .join("") +
+    (result.unlabelled.length
+      ? `<section class="result-section needs-review"><h4>Needs sorting<span>${result.unlabelled.length}</span></h4>
+          <ul>${result.unlabelled.map(itemMarkup).join("")}</ul></section>`
+      : "");
+}
+
+function renderDiff(result) {
+  const renderList = (items, empty, marker) =>
+    items.length
+      ? `<ul>${items
+          .map(
+            (item) =>
+              `<li><strong aria-hidden="true">${marker}</strong><span>${escapeHtml(
+                item.value
+              )}</span><small>Exact line from ${marker === "+" ? "new" : "old"} version</small></li>`
+          )
+          .join("")}</ul>`
+      : `<p class="missing-value">${empty}</p>`;
+  return `<div class="change-totals" aria-label="Change totals">
+      <span><strong>${result.added.length}</strong> added</span>
+      <span><strong>${result.removed.length}</strong> removed</span>
+      <span><strong>${result.unchanged.length}</strong> unchanged</span>
+    </div>
+    <section class="result-section change-added"><h4>Added<span>${result.added.length}</span></h4>
+      ${renderList(result.added, "Nothing added.", "+")}</section>
+    <section class="result-section change-removed"><h4>Removed<span>${result.removed.length}</span></h4>
+      ${renderList(result.removed, "Nothing removed.", "−")}</section>`;
+}
+
+function renderResult(result) {
+  latestResult = result;
+  outputTitle.textContent = result.title;
+  outputState.textContent = "Draft ready — check it before sharing";
+  outputState.classList.add("ready");
+  output.innerHTML = result.changes ? renderDiff(result) : renderStructured(result);
+  exportButton.disabled = false;
+  copyButton.disabled = false;
+  output.focus();
+}
+
+function resetOutput() {
+  latestResult = null;
+  outputTitle.textContent = "Your draft will appear here";
+  outputState.textContent = "Nothing has been sent or saved";
+  outputState.classList.remove("ready");
+  output.innerHTML =
+    '<div class="empty-output"><span aria-hidden="true">↳</span><p>Choose a tool, use the safe sample or paste your own text, then make a draft.</p></div>';
+  exportButton.disabled = true;
+  copyButton.disabled = true;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+tabs.forEach((tab) => tab.addEventListener("click", () => setActiveTool(tab.dataset.toolTab)));
+document.querySelectorAll("[data-open-tool]").forEach((link) => {
+  link.addEventListener("click", () => setActiveTool(link.dataset.openTool));
+});
+
+document.querySelector("#build-update").addEventListener("click", () => {
+  renderResult(buildWeeklyUpdate(document.querySelector("#update-input").value));
+});
+document.querySelector("#build-handover").addEventListener("click", () => {
+  renderResult(buildHandover(document.querySelector("#handover-input").value));
+});
+document.querySelector("#compare-change").addEventListener("click", () => {
+  renderResult(
+    compareVersions(
+      document.querySelector("#before-input").value,
+      document.querySelector("#after-input").value
+    )
+  );
+});
+
+document.querySelectorAll("[data-sample]").forEach((button) => {
+  button.addEventListener("click", () => {
+    const sample = button.dataset.sample;
+    if (sample === "update") document.querySelector("#update-input").value = samples.update;
+    if (sample === "handover") document.querySelector("#handover-input").value = samples.handover;
+    if (sample === "change") {
+      document.querySelector("#before-input").value = samples.before;
+      document.querySelector("#after-input").value = samples.after;
+    }
+  });
+});
+
+copyButton.addEventListener("click", async () => {
+  if (!latestResult) return;
+  await navigator.clipboard.writeText(resultToMarkdown(latestResult));
+  copyButton.textContent = "Copied";
+  window.setTimeout(() => (copyButton.textContent = "Copy"), 1200);
+});
+
+exportButton.addEventListener("click", () => {
+  if (!latestResult) return;
+  const blob = new Blob([resultToMarkdown(latestResult)], { type: "text/markdown" });
+  const href = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = `${latestTool}-draft.md`;
+  link.click();
+  URL.revokeObjectURL(href);
+});
+
+resetButton.addEventListener("click", resetOutput);
+resetOutput();


### PR DESCRIPTION
## What changed

- adds a browser-local Everyday Workbench for weekly updates, handovers and exact change comparison
- reframes the portfolio around recognisable work situations while preserving the technical project catalogue
- adds explicit data handling, external-action, review and exit boundaries
- updates the GitHub profile, sitemap, product context and manifest
- adds deterministic unit checks plus desktop, mobile and no-JavaScript browser QA

## Why

Research showed a clearer gap for a small, curated task store for nontechnical project and operations users than for another open-ended agent marketplace.

## Validation

- `npm test`
- Playwright desktop/mobile/no-JavaScript QA
- manual visual inspection at 1440px and 390px
- `git diff --check`